### PR TITLE
Fall back to link text for image alt when no title attribute is set

### DIFF
--- a/scripts/aem-assets.js
+++ b/scripts/aem-assets.js
@@ -106,7 +106,12 @@ function createWebOptimizedDMOpenAPIUrl(url) {
  */
 function getImageSrcUrlAndAlt(element) {
   if (element.tagName === 'A') {
-    return { url: element.getAttribute('href'), alt: element.getAttribute('title') || '' };
+    const href = element.getAttribute('href');
+    const text = element.textContent?.trim() || '';
+    // Fall back to the link's own text as alt text, unless it's just the raw URL
+    // (e.g. a pasted link with no author-supplied text), since that's not usable alt text.
+    const textAlt = text && text !== href ? text : '';
+    return { url: href, alt: element.getAttribute('title') || textAlt };
   }
 
   if (element.tagName === 'IMG') {
@@ -650,6 +655,7 @@ export async function loadBlock(block) {
 // Create an object with the test functions
 const testFunctions = {
   appendQueryParams,
+  getImageSrcUrlAndAlt,
 };
 
 // Export the object

--- a/tests/scripts/aem-assets.test.js
+++ b/tests/scripts/aem-assets.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import { testFunctions } from '../../scripts/aem-assets.js';
 
-const { appendQueryParams } = testFunctions;
+const { appendQueryParams, getImageSrcUrlAndAlt } = testFunctions;
 // scripts/aem-assets.test.js
 
 describe('appendQueryParams', () => {
@@ -31,5 +31,38 @@ describe('appendQueryParams', () => {
     const params = new Map([['rotate', '90']]);
     const result = appendQueryParams(url, params);
     expect(result).toBe('https://example.com/?existing=param&rotate=90');
+  });
+});
+
+describe('getImageSrcUrlAndAlt', () => {
+  function anchor(href, text, title) {
+    const a = document.createElement('a');
+    a.setAttribute('href', href);
+    if (title !== undefined) a.setAttribute('title', title);
+    a.textContent = text ?? '';
+    return a;
+  }
+
+  it('should use the title attribute when present', () => {
+    const a = anchor('https://example.com/asset.jpg', 'link text', 'a title');
+    expect(getImageSrcUrlAndAlt(a)).toEqual({ url: 'https://example.com/asset.jpg', alt: 'a title' });
+  });
+
+  it('should fall back to the link text when there is no title attribute', () => {
+    const a = anchor('https://example.com/asset.jpg', 'blue car with black wheels');
+    expect(getImageSrcUrlAndAlt(a)).toEqual({
+      url: 'https://example.com/asset.jpg',
+      alt: 'blue car with black wheels',
+    });
+  });
+
+  it('should not use the link text as alt when it is just the raw URL', () => {
+    const a = anchor('https://example.com/asset.jpg', 'https://example.com/asset.jpg');
+    expect(getImageSrcUrlAndAlt(a)).toEqual({ url: 'https://example.com/asset.jpg', alt: '' });
+  });
+
+  it('should return empty alt when there is no title and no text', () => {
+    const a = anchor('https://example.com/asset.jpg', '');
+    expect(getImageSrcUrlAndAlt(a)).toEqual({ url: 'https://example.com/asset.jpg', alt: '' });
   });
 });


### PR DESCRIPTION
AEM's Universal Editor/xwalk exporter only writes the alt text into the anchor's title attribute when the model field is literally named imageTitle; any other field name results in the alt text landing in the anchor's own text content instead, with no title attribute at all. getImageSrcUrlAndAlt only ever read title, so images authored through a differently-named field lost their alt text entirely.